### PR TITLE
feat(ui+api): add demo page & improve AI workout JSON parsing

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,18 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;
+const nextConfig = {
+    // Helps catch potential issues in development
+    reactStrictMode: true,
+  
+    // Proxy any request starting with /apiProxy to the Express backend
+    async rewrites() {
+      return [
+        {
+          source: '/apiProxy/:path*',
+          destination: 'http://localhost:3001/api/:path*', // backend URL
+        },
+      ];
+    },
+  };
+  
+  export default nextConfig;
+  

--- a/frontend/src/app/demo/page.js
+++ b/frontend/src/app/demo/page.js
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function DemoPage() {
+  const [loading, setLoading] = useState(false);
+  const [plans, setPlans]   = useState([]);
+
+  const generate = async () => {
+    setLoading(true);
+    const res = await fetch('/apiProxy/ai/workouts/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        goal: 'hypertrophy',
+        equipment: 'dumbbells',
+        daysPerWeek: 3,
+        coachId: 1,
+        clientId: 1,
+      }),
+    });
+    const data = await res.json();
+    setPlans(data.plans || []);
+    setLoading(false);
+  };
+
+  return (
+    <main className="p-8 max-w-xl mx-auto space-y-6">
+      <button
+        onClick={generate}
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        {loading ? 'Generating…' : 'Generate Workout'}
+      </button>
+
+      {plans.map((p) => (
+        <div key={p.id} className="border rounded p-4">
+          <h3 className="font-bold mb-2">{p.planName}</h3>
+          <pre className="text-sm whitespace-pre-wrap">
+            {JSON.stringify(p.exercises, null, 2)}
+          </pre>
+        </div>
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
## What’s inside
### Front-end
* **`src/app/demo/page.js`**
  * Simple “Generate Workout” page (App Router) that calls the AI endpoint and renders each plan.
* **`next.config.mjs`**
  * Adds `/apiProxy/*` rewrite → http://localhost:3001/api/* for seamless local dev.

### Back-end
* **`routes/aiWorkout.js`**
  * Normalizes curly quotes (“ ” / ‘ ’) before JSON5.parse so GPT output always parses.

## How to test
1. Run back-end:  `npm run dev`  (port 3001)
2. Run front-end: `npm run dev`  (port 3000)
3. Visit **/demo** → click **Generate Workout** → three-day plan cards should appear.

Everything works locally (200 OK). This demo page is handy for screenshots, Looms, and early user demos.

Closes # (if you have an issue number)
